### PR TITLE
added requirements.txt for documentation build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+stsci_rtd_theme
+numpy
+matplotlib


### PR DESCRIPTION
## Description

Adds a requirements.txt file in the docs folder so that readthedocs.org can do a documentation buld 

Fixes: None

## How Has This Been Tested?

N/A
