### PR TITLE
Changed os.pathsep to forward-slash

### DIFF
--- a/abscal/common/utils.py
+++ b/abscal/common/utils.py
@@ -84,7 +84,7 @@ def get_base_data_dir():
             return os.environ["abscal_data"]
     
     # Fall back to internal
-    return os.path.dirname(os.path.abspath(__file__))
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def get_data_file(module, fname, defaults=False):
@@ -123,7 +123,7 @@ def get_data_file(module, fname, defaults=False):
     module = module.replace("abscal.", "")
     
     # Replace '.' with path separator
-    module_path = module.replace(".", os.pathsep)
+    module_path = module.replace(".", "/")
 
     data_path = os.path.join(current_loc, module_path, "data")
     if defaults:


### PR DESCRIPTION
## Description

Although it's not technically correct, for some reason os.pathsep seems to give inconsistent results, and sometimes fails to build usable paths.

Fixes: None

## How Has This Been Tested?

N/A