### PR TITLE
Removed unnecessary/redundant requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,0 @@
-stsci_rtd_theme
-sphinx_autoapi
-nbsphinx
-jupyter
-IPython
-ipykernel
-astroquery


### PR DESCRIPTION
## Description

Because the repository now has an explicit ".readthedocs.yaml" file, which points to the environment.yml file, there is no longer a need for a separate requirements.txt (which would then have to be kept in sync).

Fixes: None

## How Has This Been Tested?

N/A